### PR TITLE
Updated medicinal product definition

### DIFF
--- a/input/fsh/profiles/AdministrableProductDefinitionWhoPhP.fsh
+++ b/input/fsh/profiles/AdministrableProductDefinitionWhoPhP.fsh
@@ -1,4 +1,4 @@
-// TODO: VCN2025 - Check that this profile is up to date        
+// TODO: VCN2025 - Check that this profile is up to date
 Profile: AdministrableProductDefinitionWhoPhP
 Parent: AdministrableProductDefinition
 Id: AdministrableProductDefinition-who-php
@@ -37,7 +37,7 @@ Description: "This profile specified how the AdministrableProductDefinition is p
 //   * extension contains $data-absent-reason named data-absent-reason 0..
 //   * extension[data-absent-reason].valueCode = #unsupported
 
-// ADF is intended to be like shewable tablet acc to EDQM. 
+// ADF is intended to be like chewable tablet acc to EDQM. 
 // The PhPID is only using Tablet as concept (the BDF) so two APDs with similar (but different) ADFs will have the same PhPID
 // Therefore... we do not use ADF but the extensions associated with the Pharmaceutical Form
 * administrableDoseForm 0..0

--- a/input/fsh/profiles/IngredientWhoPhP.fsh
+++ b/input/fsh/profiles/IngredientWhoPhP.fsh
@@ -20,7 +20,7 @@ Description: """This profile specified how the Ingredient is used in a PhPID req
       * system 1..1
       * code 1..1 //gsid value
     * text 1..1 //substance name
-  * strength 1..1
+  * strength 1..1 // Enforce that one of the three following properties are set
     * ^short = "The quantity of substance, per presentation, or per volume or mass, and type of quantity."
     * presentationRatio 0..1
       * numerator 1..1
@@ -40,8 +40,6 @@ Description: """This profile specified how the Ingredient is used in a PhPID req
     // TODO: VCN2025 - redundant - check if needed for IG clarity?
     * textPresentation 0..1 //strength freetext
       * ^short = "Should only be used if the strength cannot be coded."
-    // TODO: VCN2025 - allow ref strength
-    * referenceStrength 0..0
 //*******************************
 // Publish model
 //*******************************

--- a/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
+++ b/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
@@ -79,7 +79,7 @@ RuleSet: MedicinalProductDefinitionCommon
     * country ^short = "Country where this name applies"
     * country 1..1 
       * coding 1..1
-        * code 1..1    
+        * code 1..1
         * code from VsCountry (example)
     * jurisdiction ^short = "Jurisdiction where this name applies"
       * coding 1..1
@@ -89,7 +89,6 @@ RuleSet: MedicinalProductDefinitionCommon
     
 // NOT USED ELEMENTS
 
-// TODO: VCN2025 - Verify that those can be sent even if we ignore them
 * insert NotUsed(statusDate)
 * insert NotUsed(legalStatusOfSupply)
 * insert NotUsed(additionalMonitoringIndicator)

--- a/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
+++ b/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
@@ -66,13 +66,10 @@ RuleSet: MedicinalProductDefinitionCommon
 * classification from VsAtcClassification (example)
   * ^short = "Allows the product to be classified by various systems (e.g. ATC)"
 
-// TODO: VCN2025 - allow for multiple names where type is required 
 // Need to investigate which type we should use (and require?)
 * name 1..
   * productName 1..1
   * productName ^short = "The full product name."
-  // TODO: VCN2025 - type should be allowed (and req if more than one name?!)
-  * insert NotUsed(type)
 
   * part 0..*
     * part ^short = "A fragment of a product name."

--- a/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
+++ b/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
@@ -12,10 +12,9 @@ Description: """This profile specified how the MedicinalProductDefinition is use
   * system 1..
   * system from VsMpIdSystem (extensible)
   * value 1..
-// TODO: VCN2025 - describe clearly (for IG) that this is MAH (NOT requester)         
 * contact 1..1
   * type ^short = "Should be ProposedMAH"
-  * contact ^short = "A specific contact, person (in a role), or an organization for this product"
+  * contact ^short = "A specific contact that represents an organization that is the market authorization holder for this product."
   * contact only Reference(MarketingAuthorizationHolder-who-php)
 * description ^short = "General description of the medicinal product referred by the ePI"
 * indication ^short = "Narrative text of the authorized indication(s) for this product."

--- a/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
+++ b/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
@@ -80,13 +80,11 @@ RuleSet: MedicinalProductDefinitionCommon
     * country 1..1 
       * coding 1..1
         * code 1..1    
-        // TODO: VCN2025 - Should accept "all" systems and map
-        * system = $iso3166
+        * code from VsCountry (example)
     * jurisdiction ^short = "Jurisdiction where this name applies"
       * coding 1..1
         * code 1..1    
-        // TODO: VCN2025 - Should accept "all" systems and map
-        * code from VsJurisdiction
+        * code from VsJurisdiction (example)
     * language ^short = "Language for this name"
     
 // NOT USED ELEMENTS

--- a/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
+++ b/input/fsh/profiles/MedicinalProductDefinitionWhoPhP.fsh
@@ -80,10 +80,10 @@ RuleSet: MedicinalProductDefinitionCommon
     * country 1..1 
       * coding 1..1
         * code 1..1
-        * code from VsCountry (example)
+        * system = $iso3166
     * jurisdiction ^short = "Jurisdiction where this name applies"
       * coding 1..1
-        * code 1..1    
+        * code 1..1
         * code from VsJurisdiction (example)
     * language ^short = "Language for this name"
     


### PR DESCRIPTION
* Typo fix
* Reference strength is inherited from parent and not used further down the IDMP chain, so no need to limit it here
* Clarified text about MAH contact
* Allowing multiple names for MPD and removed NotUsed(type) as an insert
* Removed iso3166 as system, since it is already set by parent. Included VsCountry and VsJurisdiction as examples
* Verified that statusDate could be submitted in IDMP API even though it isn't used.