### PR TITLE
Remove strengthRatio and strengthRatioRange from reference strength

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ __pycache__/
 .vscode
 .jekyll-cache
 _site
+.claude/settings.local.json

--- a/input/fsh/profiles/IngredientPhPIdPub.fsh
+++ b/input/fsh/profiles/IngredientPhPIdPub.fsh
@@ -48,10 +48,6 @@ Description: "This profile defines how the Ingredient is used for PhPID publish 
   * insert NotUsed(strength.presentationRatioRange)
   * insert NotUsed(strength.presentationCodeableConcept)
 
-  * strength.referenceStrength
-    * insert NotUsed(strengthRatio)
-    * insert NotUsed(strengthRatioRange)
-
   * strength.referenceStrength ^short = "Strength expressed in terms of a reference substance"
   * strength.referenceStrength 0..1
     * insert NotUsed(modifierExtension)
@@ -65,6 +61,7 @@ Description: "This profile defines how the Ingredient is used for PhPID publish 
         * code 1..1
       * text 0..1
 
+    * strength[x] only Quantity
     * strength[x] ^short = "Strength of the reference substance."
 
 

--- a/input/fsh/profiles/IngredientPhPIdReq.fsh
+++ b/input/fsh/profiles/IngredientPhPIdReq.fsh
@@ -25,10 +25,6 @@ Description: "This profile defines how the Ingredient is used for request (as co
     * textPresentation 0..1 //strength freetext
       * ^short = "Should only be used if the strength cannot be coded."
 
-  * strength.referenceStrength
-    * insert NotUsed(strengthRatio)
-    * insert NotUsed(strengthRatioRange)
-
   * strength.referenceStrength ^short = "Strength expressed in terms of a reference substance"
   * strength.referenceStrength 0..1
     * insert NotUsed(modifierExtension)
@@ -41,6 +37,7 @@ Description: "This profile defines how the Ingredient is used for request (as co
         * code 1..1
       * text 0..1
 
+    * strength[x] only Quantity
     * strength[x] ^short = "Strength of the reference substance."
 
 * obeys presentation-required


### PR DESCRIPTION
Removed  strengthRatio and strengthRatioRange from reference strength. We previously marked them as NotUsed but now they are removed from the resources.